### PR TITLE
Fix AJAX action name

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -15,7 +15,7 @@ jQuery(document).ready(function($) {
         $this.prop('disabled', true).text('Réservation en cours...');
 
         $.post(jdeKiosquesAjax.ajax_url, {
-            action: 'reserve_kiosk',
+            action: 'jde_kiosques_reserve',
             kiosk_number: kioskID,
             partner_code: partnerCode,
             security: jdeKiosquesAjax.nonce


### PR DESCRIPTION
## Summary
- fix AJAX action string so jQuery uses the correct WordPress hook

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684f78b38c8483229b3425f035777f11